### PR TITLE
Revert "MEPTS-73: Add exclusion on TxCurr"

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TxCurrCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TxCurrCohortQueries.java
@@ -39,12 +39,6 @@ public class TxCurrCohortQueries {
 	        + "and obs.obs_datetime = (select max(encounter.encounter_datetime) from encounter "
 	        + "where encounter.encounter_type in (%s) and encounter.patient_id = obs.person_id and encounter.location_id = obs.location_id and encounter.voided = false and encounter.encounter_datetime <= :onOrBefore) ";
 	
-	private static final String EXCLUDE_PATIENTS_ENRROLLED_BUT_WITHOUT_CONSULTATION = "select distinct(person.person_id) "
-	        + "from patient_program join person on person.person_id = patient_program.patient_id "
-	        + "    left join encounter on (encounter.patient_id = patient_program.patient_id and encounter.location_id = :location) "
-	        + "where patient_program.location_id = :location and patient_program.program_id = %s "
-	        + "    and person.voided = 0 and encounter.patient_id is null ";
-	
 	private static final int OLD_SPEC_ABANDONMENT_DAYS = 60;
 	
 	private static final int CURRENT_SPEC_ABANDONMENT_DAYS = 31;
@@ -255,22 +249,6 @@ public class TxCurrCohortQueries {
 	}
 	
 	/**
-	 * Patients enrolled on ART Program but without at least any consultation/pickup(without record
-	 * on obs)
-	 * 
-	 * @return
-	 */
-	@DocumentedDefinition(value = "patientsEnrrolledOnArtWithoutAnyConsultation")
-	public SqlCohortDefinition getPatientsEnrrolledOnArtWithoutAnyConsultation() {
-		SqlCohortDefinition definition = new SqlCohortDefinition();
-		definition.setName("patientsEnrrolledOnArtWithoutAnyConsultation");
-		definition.setQuery(String.format(EXCLUDE_PATIENTS_ENRROLLED_BUT_WITHOUT_CONSULTATION, hivMetadata.getARTProgram()
-		        .getProgramId()));
-		definition.addParameter(new Parameter("location", "location", Location.class));
-		return definition;
-	}
-	
-	/**
 	 * Build TxCurr composition cohort definition
 	 * 
 	 * @param cohortName
@@ -295,8 +273,7 @@ public class TxCurrCohortQueries {
 	        CohortDefinition patientsThatMissedNexPickup, CohortDefinition patientsThatDidNotMissNextConsultation,
 	        CohortDefinition patientsReportedAsAbandonmentButStillInPeriod, CohortDefinition ageCohort,
 	        CohortDefinition genderCohort, CohortDefinition patientsWithNextPickupDate,
-	        CohortDefinition patientsWithNextConsultationDate,
-	        CohortDefinition patientsEnrrolledOnArtWithoutAnyConsultation, boolean currentSpec) {
+	        CohortDefinition patientsWithNextConsultationDate, boolean currentSpec) {
 		
 		final int abandonmentDays = currentSpec ? CURRENT_SPEC_ABANDONMENT_DAYS : OLD_SPEC_ABANDONMENT_DAYS;
 		CompositionCohortDefinition TxCurrComposition = new CompositionCohortDefinition();
@@ -351,16 +328,11 @@ public class TxCurrCohortQueries {
 		TxCurrComposition.addSearch("baseCohort",
 		    EptsReportUtils.map(genericCohorts.getBaseCohort(), "endDate=${onOrBefore},location=${location}"));
 		
-		TxCurrComposition.getSearches().put(
-		    "13",
-		    new Mapped<CohortDefinition>(patientsEnrrolledOnArtWithoutAnyConsultation, ParameterizableUtil
-		            .createParameterMappings("location=${location}")));
-		
 		String compositionString;
 		if (currentSpec) {
-			compositionString = "(1 OR 2 OR 3 OR 4) AND (NOT (5 OR ((6 OR (NOT 11)) AND (NOT (7 OR 8))))) AND (11 OR 12) AND NOT 13";
+			compositionString = "(1 OR 2 OR 3 OR 4) AND (NOT (5 OR ((6 OR (NOT 11)) AND (NOT (7 OR 8))))) AND (11 OR 12)";
 		} else {
-			compositionString = "(1 OR 2 OR 3 OR 4) AND (NOT (5 OR (6 AND (NOT (7 OR 8))))) AND NOT 13";
+			compositionString = "(1 OR 2 OR 3 OR 4) AND (NOT (5 OR (6 AND (NOT (7 OR 8)))))";
 		}
 		
 		if (ageCohort != null) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/TxCurrDataset.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/TxCurrDataset.java
@@ -1,13 +1,15 @@
 /*
- * The contents of this file are subject to the OpenMRS Public License Version
- * 1.0 (the "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at http://license.openmrs.org
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
  *
- * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
  */
 
 package org.openmrs.module.eptsreports.reporting.library.datasets;
@@ -72,8 +74,6 @@ public class TxCurrDataset extends BaseDataSet {
 		        .getPatientsReportedAsAbandonmentButStillInPeriod();
 		SqlCohortDefinition patientsWithNextPickupDate = txCurrCohortQueries.getPatientsWithNextPickupDate();
 		SqlCohortDefinition patientsWithNextConsultationDate = txCurrCohortQueries.getPatientsWithNextConsultationDate();
-		SqlCohortDefinition patientsEnrrolledOnArtWithoutAnyConsultation = txCurrCohortQueries
-		        .getPatientsEnrrolledOnArtWithoutAnyConsultation();
 		
 		CohortDefinition males = genderCohortQueries.MaleCohort();
 		CohortDefinition females = genderCohortQueries.FemaleCohort();
@@ -92,8 +92,7 @@ public class TxCurrDataset extends BaseDataSet {
 			    enrolledBeforeEndDate, patientWithSTARTDRUGSObs, patientWithHistoricalDrugStartDateObs,
 			    patientsWithDrugPickUpEncounters, patientsWhoLeftARTProgramBeforeOrOnEndDate, patientsThatMissedNexPickup,
 			    patientsThatDidNotMissNextConsultation, patientsReportedAsAbandonmentButStillInPeriod, ageCohort, males,
-			    patientsWithNextPickupDate, patientsWithNextConsultationDate, patientsEnrrolledOnArtWithoutAnyConsultation,
-			    currentSpec);
+			    patientsWithNextPickupDate, patientsWithNextConsultationDate, currentSpec);
 			CohortIndicator indicator = hivIndicators
 			        .patientInYearRangeEnrolledInHIVStartedARTIndicatorBeforeOrOnEndDate(rangeMales);
 			dataSetDefinition.addColumn(
@@ -113,8 +112,7 @@ public class TxCurrDataset extends BaseDataSet {
 			    patientWithHistoricalDrugStartDateObs, patientsWithDrugPickUpEncounters,
 			    patientsWhoLeftARTProgramBeforeOrOnEndDate, patientsThatMissedNexPickup,
 			    patientsThatDidNotMissNextConsultation, patientsReportedAsAbandonmentButStillInPeriod, ageCohort, females,
-			    patientsWithNextPickupDate, patientsWithNextConsultationDate, patientsEnrrolledOnArtWithoutAnyConsultation,
-			    currentSpec);
+			    patientsWithNextPickupDate, patientsWithNextConsultationDate, currentSpec);
 			CohortIndicator indicator = hivIndicators
 			        .patientInYearRangeEnrolledInHIVStartedARTIndicatorBeforeOrOnEndDate(rangeFemales);
 			dataSetDefinition.addColumn(
@@ -130,7 +128,7 @@ public class TxCurrDataset extends BaseDataSet {
 		    patientsWithDrugPickUpEncounters, patientsWhoLeftARTProgramBeforeOrOnEndDate, patientsThatMissedNexPickup,
 		    patientsThatDidNotMissNextConsultation, patientsReportedAsAbandonmentButStillInPeriod,
 		    genericCohortQueries.getUnknownAgeCohort(), males, patientsWithNextPickupDate, patientsWithNextConsultationDate,
-		    patientsEnrrolledOnArtWithoutAnyConsultation, currentSpec);
+		    currentSpec);
 		CohortIndicator unknownMalesIndicator = hivIndicators
 		        .patientEnrolledInHIVStartedARTIndicatorBeforeOrOnEndDate(unknownMales);
 		dataSetDefinition.addColumn("C1UNKM", "TX_CURR: Unknown Age", new Mapped<CohortIndicator>(unknownMalesIndicator,
@@ -142,7 +140,7 @@ public class TxCurrDataset extends BaseDataSet {
 		    patientsWithDrugPickUpEncounters, patientsWhoLeftARTProgramBeforeOrOnEndDate, patientsThatMissedNexPickup,
 		    patientsThatDidNotMissNextConsultation, patientsReportedAsAbandonmentButStillInPeriod,
 		    genericCohortQueries.getUnknownAgeCohort(), females, patientsWithNextPickupDate,
-		    patientsWithNextConsultationDate, patientsEnrrolledOnArtWithoutAnyConsultation, currentSpec);
+		    patientsWithNextConsultationDate, currentSpec);
 		CohortIndicator unknownFemalesIndicator = hivIndicators
 		        .patientEnrolledInHIVStartedARTIndicatorBeforeOrOnEndDate(unknownFemales);
 		dataSetDefinition.addColumn("C1UNKF", "TX_CURR: Unknown Age", new Mapped<CohortIndicator>(unknownFemalesIndicator,
@@ -153,8 +151,7 @@ public class TxCurrDataset extends BaseDataSet {
 		    enrolledBeforeEndDate, patientWithSTARTDRUGSObs, patientWithHistoricalDrugStartDateObs,
 		    patientsWithDrugPickUpEncounters, patientsWhoLeftARTProgramBeforeOrOnEndDate, patientsThatMissedNexPickup,
 		    patientsThatDidNotMissNextConsultation, patientsReportedAsAbandonmentButStillInPeriod, null, null,
-		    patientsWithNextPickupDate, patientsWithNextConsultationDate, patientsEnrrolledOnArtWithoutAnyConsultation,
-		    currentSpec);
+		    patientsWithNextPickupDate, patientsWithNextConsultationDate, currentSpec);
 		CohortIndicator allIndicator = hivIndicators.patientEnrolledInHIVStartedARTIndicatorBeforeOrOnEndDate(all);
 		dataSetDefinition.addColumn("C1All", "TX_CURR: Currently on ART", new Mapped<CohortIndicator>(allIndicator,
 		        ParameterizableUtil.createParameterMappings("endDate=${endDate},location=${location}")), "");


### PR DESCRIPTION
Reverts esaude/openmrs-module-eptsreports#34

Speaking to Pinki about this PR, and there seems to be some miscommunication. This only affects TxCurr2.1 which we don't need to change since it follows the old spec which is why I am reverting this PR.