### PR TITLE
MEPTS-87: Refactored 4month retention indicator

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/Eri4MonthsDataset.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/Eri4MonthsDataset.java
@@ -35,7 +35,7 @@ public class Eri4MonthsDataset extends BaseDataSet {
 
   public DataSetDefinition constructEri4MonthsDatset() {
     CohortIndicatorDataSetDefinition dsd = new CohortIndicatorDataSetDefinition();
-    String mappings = "startDate=${startDate},endDate=${endDate},location=${location}";
+    String mappings = "startDate=${endDate-4m+1d},endDate=${endDate-3m},location=${location}";
     dsd.setName("ERI-4months Data Set");
     dsd.addParameters(getParameters());
 
@@ -52,9 +52,8 @@ public class Eri4MonthsDataset extends BaseDataSet {
             eptsGeneralIndicator.getIndicator(
                 "all patients",
                 EptsReportUtils.map(
-                    eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(),
-                    "endDate=${endDate},location=${location}")),
-            "endDate=${endDate},location=${location}"),
+                    eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(), mappings)),
+            mappings),
         get4MonthsRetentionColumns());
     addRow(
         dsd,

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/Eri4MonthsDataset.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/datasets/Eri4MonthsDataset.java
@@ -35,13 +35,14 @@ public class Eri4MonthsDataset extends BaseDataSet {
 
   public DataSetDefinition constructEri4MonthsDatset() {
     CohortIndicatorDataSetDefinition dsd = new CohortIndicatorDataSetDefinition();
-    String mappings = "startDate=${endDate-4m+1d},endDate=${endDate-3m},location=${location}";
+    String mappingsInd = "startDate=${endDate-4m+1d},endDate=${endDate-3m},location=${location}";
+    String mappings = "startDate=${startDate},endDate=${endDate},location=${location}";
     dsd.setName("ERI-4months Data Set");
     dsd.addParameters(getParameters());
 
     // apply disaggregations here
     dsd.addDimension(
-        "state", EptsReportUtils.map(eptsCommonDimension.getEri4MonthsDimension(), mappings));
+        "state", EptsReportUtils.map(eptsCommonDimension.getEri4MonthsDimension(), mappingsInd));
 
     // start forming the columns
     addRow(
@@ -52,7 +53,8 @@ public class Eri4MonthsDataset extends BaseDataSet {
             eptsGeneralIndicator.getIndicator(
                 "all patients",
                 EptsReportUtils.map(
-                    eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(), mappings)),
+                    eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(),
+                    mappingsInd)),
             mappings),
         get4MonthsRetentionColumns());
     addRow(
@@ -65,7 +67,7 @@ public class Eri4MonthsDataset extends BaseDataSet {
                 EptsReportUtils.map(
                     eri4MonthsCohortQueries
                         .getPregnantWomenRetainedOnArtFor4MonthsFromArtInitiation(),
-                    mappings)),
+                    mappingsInd)),
             mappings),
         get4MonthsRetentionColumns());
     addRow(
@@ -78,7 +80,7 @@ public class Eri4MonthsDataset extends BaseDataSet {
                 EptsReportUtils.map(
                     eri4MonthsCohortQueries
                         .getBreastfeedingWomenRetainedOnArtFor4MonthsFromArtInitiation(),
-                    mappings)),
+                    mappingsInd)),
             mappings),
         get4MonthsRetentionColumns());
     addRow(
@@ -90,7 +92,7 @@ public class Eri4MonthsDataset extends BaseDataSet {
                 "children",
                 EptsReportUtils.map(
                     eri4MonthsCohortQueries.getChildrenRetainedOnArtFor4MonthsFromArtInitiation(),
-                    mappings)),
+                    mappingsInd)),
             mappings),
         get4MonthsRetentionColumns());
     addRow(
@@ -102,7 +104,7 @@ public class Eri4MonthsDataset extends BaseDataSet {
                 "adults",
                 EptsReportUtils.map(
                     eri4MonthsCohortQueries.getAdultsRetaineOnArtFor4MonthsFromArtInitiation(),
-                    mappings)),
+                    mappingsInd)),
             mappings),
         get4MonthsRetentionColumns());
     return dsd;

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
@@ -226,28 +226,24 @@ public class EptsCommonDimension {
     dim.addParameter(new Parameter("endDate", "End Date", Date.class));
     dim.addParameter(new Parameter("location", "location", Location.class));
     dim.setName("Get patient states");
+    String mappings = "startDate=${startDate},endDate=${endDate},location=${location}";
     dim.addCohortDefinition(
         "IART",
         EptsReportUtils.map(
-            eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(),
-            "endDate=${endDate},location=${location}"));
+            eri4MonthsCohortQueries.getPatientsWhoInitiatedArtLessTransferIns(), mappings));
 
     dim.addCohortDefinition(
         "AIT",
         EptsReportUtils.map(
-            eri4MonthsCohortQueries.getPatientsWhoAreAliveAndOnTreatment(),
-            "endDate=${endDate},location=${location}"));
+            eri4MonthsCohortQueries.getPatientsWhoAreAliveAndOnTreatment(), mappings));
 
     dim.addCohortDefinition(
-        "DP",
-        EptsReportUtils.map(
-            genericCohortQueries.getDeceasedPatients(), "endDate=${endDate},location=${location}"));
+        "DP", EptsReportUtils.map(genericCohortQueries.getDeceasedPatients(), mappings));
 
     dim.addCohortDefinition(
         "LTFU",
         EptsReportUtils.map(
-            eri4MonthsCohortQueries.getAllPatientsWhoAreLostToFollowUpDuringPeriod(),
-            "endDate=${endDate},location=${location}"));
+            eri4MonthsCohortQueries.getAllPatientsWhoAreLostToFollowUpDuringPeriod(), mappings));
 
     dim.addCohortDefinition(
         "TOP",
@@ -257,14 +253,14 @@ public class EptsCommonDimension {
                 hivMetadata
                     .getTransferredOutToAnotherHealthFacilityWorkflowState()
                     .getProgramWorkflowStateId()),
-            "endDate=${endDate},location=${location}"));
+            mappings));
     dim.addCohortDefinition(
         "STP",
         EptsReportUtils.map(
             genericCohortQueries.getPatientsBasedOnPatientStates(
                 hivMetadata.getARTProgram().getProgramId(),
                 hivMetadata.getSuspendedTreatmentWorkflowState().getProgramWorkflowStateId()),
-            "endDate=${endDate},location=${location}"));
+            mappings));
     return dim;
   }
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/Eri4MonthsQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/Eri4MonthsQueries.java
@@ -80,7 +80,7 @@ public class Eri4MonthsQueries {
         + ") inicio"
         + " GROUP BY patient_id"
         + ") inicio1"
-        + " WHERE data_inicio BETWEEN date_add(date_add(:endDate, interval -4 month), interval 1 day) AND date_add(:endDate, interval -3 month)"
+        + " WHERE data_inicio BETWEEN :startDate AND :endDate "
         + ") inicio_real"
         + " INNER JOIN encounter e ON e.patient_id=inicio_real.patient_id"
         + " WHERE e.voided=0 AND e.encounter_type IN("
@@ -103,7 +103,7 @@ public class Eri4MonthsQueries {
         + " AND ps.state="
         + transferFromStates
         + " AND ps.start_date=pg.date_enrolled AND"
-        + " ps.start_date BETWEEN date_add(date_add(:endDate, interval -4 month), interval 1 day) AND date_add(:endDate, interval -3 month) and location_id=:location"
+        + " ps.start_date BETWEEN :startDate AND :endDate and location_id=:location"
         + ")"
         + " GROUP BY inicio_real.patient_id";
   }
@@ -174,23 +174,9 @@ public class Eri4MonthsQueries {
         + ") inicio "
         + "GROUP BY patient_id "
         + ")inicio1 "
-        + "WHERE data_inicio BETWEEN date_add(date_add(:endDate, interval -4 month), interval 1 day) and date_add(:endDate, interval -3 month) "
+        + "WHERE data_inicio BETWEEN :startDate and :endDate "
         + ") inicio_real "
         + "GROUP BY inicio_real.patient_id";
-  }
-
-  public static String getTransferInPatients(int artProgram, int transferFromState) {
-    return "SELECT pg.patient_id "
-        + "FROM patient p "
-        + "INNER JOIN patient_program pg on p.patient_id=pg.patient_id "
-        + "INNER JOIN patient_state ps on pg.patient_program_id=ps.patient_program_id "
-        + "WHERE pg.voided=0 and ps.voided=0 AND p.voided=0 AND  "
-        + "pg.program_id="
-        + artProgram
-        + " AND ps.state="
-        + transferFromState
-        + " AND ps.start_date=pg.date_enrolled AND "
-        + "ps.start_date BETWEEN date_add(date_add(:endDate, interval -4 month), interval 1 day) AND date_add(:endDate, interval -3 month) AND location_id=:location";
   }
 
   public static String getLostToFollowUpPatientsWithPeriod(
@@ -210,7 +196,7 @@ public class Eri4MonthsQueries {
         + "o.voided=0 AND o.concept_id= "
         + missedDrugsConceptId
         + " AND o.location_id=:location AND encounter_datetime BETWEEN "
-        + "date_add(date_add(:endDate, interval -4 month), interval 1 day) and date_add(:endDate, interval -3 month) "
+        + ":startDate and :endDate "
         + " UNION "
         + "SELECT patient_id, value_datetime FROM( SELECT p.patient_id,MAX(encounter_datetime)AS encounter_datetime "
         + "FROM patient p INNER JOIN encounter e ON e.patient_id=p.patient_id WHERE p.voided=0 AND e.voided=0 AND "
@@ -223,7 +209,7 @@ public class Eri4MonthsQueries {
         + "WHERE max_mov.encounter_datetime=o.obs_datetime AND o.voided=0 AND o.concept_id="
         + returnVisitConcept
         + " AND o.location_id=:location "
-        + "AND encounter_datetime BETWEEN date_add(date_add(:endDate, interval -4 month), interval 1 day) and date_add(:endDate, interval -3 month) "
+        + "AND encounter_datetime BETWEEN :startDate and :endDate "
         + ") final WHERE datediff(:endDate,final.value_datetime)>="
         + daysThreshold;
   }


### PR DESCRIPTION
refactored SQL queries to shift the data manipulation to the dataset and
replaced trasnferedin custom query with generic query aleady used for
trasnfered out. Then udpated all the parameters to pass the start adn
end dates down the line.

