### PR TITLE
Disabled openmrs formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,15 @@
                     </execution>
                 </executions>
             </plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+				<artifactId>maven-java-formatter-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
 
 			<!-- Code Coverage Tool -->
 			<plugin>


### PR DESCRIPTION
Openmrs default formatter is using an older plugin which is has not been
maintained. We have replaced with a newer plugin and are disabling the
old one so the code does not get reformatted twice each time we compile the module.