### PR TITLE
Bug fixs for TxTB numerator

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
@@ -182,11 +182,8 @@ public class TXTBCohortQueries {
             TXTBQueries.dateObs(
                 tbMetadata.getTBDrugTreatmentStartDate().getConceptId(),
                 Arrays.asList(
-                    tbMetadata.getTBLivroEncounterType().getId(),
                     hivMetadata.getAdultoSeguimentoEncounterType().getId(),
-                    hivMetadata.getARVPediatriaSeguimentoEncounterType().getId(),
-                    tbMetadata.getTBRastreioEncounterType().getId(),
-                    tbMetadata.getTBProcessoEncounterType().getId()),
+                    hivMetadata.getARVPediatriaSeguimentoEncounterType().getId()),
                 true));
     addGeneralParameters(definition);
     return definition;
@@ -700,11 +697,8 @@ public class TXTBCohortQueries {
             TXTBQueries.dateObsWithinXMonthsBeforeStartDate(
                 tbMetadata.getTBDrugTreatmentStartDate().getConceptId(),
                 Arrays.asList(
-                    tbMetadata.getTBLivroEncounterType().getId(),
                     hivMetadata.getAdultoSeguimentoEncounterType().getId(),
-                    hivMetadata.getARVPediatriaSeguimentoEncounterType().getId(),
-                    tbMetadata.getTBRastreioEncounterType().getId(),
-                    tbMetadata.getTBProcessoEncounterType().getId()),
+                    hivMetadata.getARVPediatriaSeguimentoEncounterType().getId()),
                 6));
     addGeneralParameters(cd);
     return cd;
@@ -766,10 +760,13 @@ public class TXTBCohortQueries {
     CohortDefinition A = txTbNumeratorA();
     cd.addSearch("A", map(A, generalParameterMapping));
 
-    CohortDefinition B = startedTbTreatmentWith6MonthsBeforeStartDate();
-    cd.addSearch("B", map(B, generalParameterMapping));
+    cd.addSearch(
+        "started-tb-treatment-previous-period",
+        EptsReportUtils.map(
+            tbTreatmentStartDateWithinReportingDate(),
+            "startDate=${startDate-6m},endDate=${startDate-1d},location=${location}"));
 
-    cd.setCompositionString("A NOT B");
+    cd.setCompositionString("A NOT started-tb-treatment-previous-period");
     addGeneralParameters(cd);
     return cd;
   }
@@ -886,7 +883,7 @@ public class TXTBCohortQueries {
         "started-before-start-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getStartedArtBeforeDate(false),
-            "onOrBefore=${startDate},location=${location}"));
+            "onOrBefore=${startDate-1d},location=${location}"));
     cd.setCompositionString("NUM AND started-before-start-reporting-period");
     addGeneralParameters(cd);
     return cd;

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
@@ -171,7 +171,7 @@ public class TXTBQueries {
             + "where encounter_type in(%s)) and location_id = :location "
             + "and value_datetime >= DATE_SUB(:startDate, INTERVAL "
             + "%s MONTH) "
-            + "and value_datetime <= :startDate and voided=0",
+            + "and value_datetime < :startDate and voided=0",
         questionId, StringUtils.join(encounterTypeIds, ","), xMonths);
   }
 


### PR DESCRIPTION
Bug1: in query for patients previously on TB in 6 month prior to
startDate, we were checking <=StartDate

Bug2: for same query we only needed to check for encounter types 6,9.
Encoutner types 20&26  nolonger being used

Bug3: perviousOnART we needed to check for <startDate not <= We updated
the parameter for this one.