### PR TITLE
MEPTS-171 Refactor CalculationCohortDefinition

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/common/EPTSCalculationService.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/common/EPTSCalculationService.java
@@ -65,7 +65,8 @@ public class EPTSCalculationService {
     if (encounterTypes != null) {
       def.setEncounterTypeList(encounterTypes);
     }
-    def.setOnOrBefore(context.getNow());
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    def.setOnOrBefore(onOrBefore);
     if (startDate != null) {
       def.setOnOrAfter(startDate);
     }
@@ -94,7 +95,8 @@ public class EPTSCalculationService {
       PatientCalculationContext context) {
     JembiPatientStateDefinition def = new JembiPatientStateDefinition();
     def.setLocation(location);
-    def.setStartedOnOrBefore(context.getNow());
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    def.setStartedOnOrBefore(onOrBefore);
     def.setStates(Arrays.asList(programWorkflowState));
     def.setWhich(TimeQualifier.ANY);
     return EptsCalculationUtils.evaluateWithReporting(def, cohort, null, null, context);
@@ -118,7 +120,8 @@ public class EPTSCalculationService {
       PatientCalculationContext context) {
     JembiPatientStateDefinition def = new JembiPatientStateDefinition();
     def.setLocation(location);
-    def.setStartedOnOrBefore(context.getNow());
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    def.setStartedOnOrBefore(onOrBefore);
     def.setStates(states);
     def.setWhich(TimeQualifier.ANY);
     return EptsCalculationUtils.evaluateWithReporting(def, cohort, null, null, context);
@@ -139,7 +142,8 @@ public class EPTSCalculationService {
     def.setName("All in " + program.getName());
     def.setWhichEnrollment(TimeQualifier.ANY);
     def.setProgram(program);
-    def.setEnrolledOnOrBefore(context.getNow());
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    def.setEnrolledOnOrBefore(onOrBefore);
     return EptsCalculationUtils.evaluateWithReporting(def, cohort, null, null, context);
   }
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/BreastfeedingDateCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/BreastfeedingDateCalculation.java
@@ -57,7 +57,8 @@ public class BreastfeedingDateCalculation extends AbstractPatientCalculation {
     Concept yes = hivMetadata.getYesConcept();
     Concept criteriaForHivStart = hivMetadata.getCriteriaForArtStart();
     Concept priorDeliveryDate = hivMetadata.getPriorDeliveryDateConcept();
-    Date oneYearBefore = EptsCalculationUtils.addMonths(context.getNow(), -12);
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    Date oneYearBefore = EptsCalculationUtils.addMonths(onOrBefore, -12);
 
     // get female patients only
     Set<Integer> femaleCohort = EptsCalculationUtils.female(cohort, context);
@@ -105,7 +106,7 @@ public class BreastfeedingDateCalculation extends AbstractPatientCalculation {
             viralLoadConcept,
             location,
             oneYearBefore,
-            context.getNow(),
+            onOrBefore,
             femaleCohort,
             context);
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/OnArtForMoreThanXmonthsCalcultion.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/OnArtForMoreThanXmonthsCalcultion.java
@@ -58,14 +58,15 @@ public class OnArtForMoreThanXmonthsCalcultion extends AbstractPatientCalculatio
             Context.getRegisteredComponents(InitialArtStartDateCalculation.class).get(0),
             cohort,
             context);
-    Date oneYearBefore = EptsCalculationUtils.addMonths(context.getNow(), -12);
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    Date oneYearBefore = EptsCalculationUtils.addMonths(onOrBefore, -12);
     CalculationResultMap lastVl =
         ePTSCalculationService.lastObs(
             Arrays.asList(labEncounterType, adultFollowup, childFollowup),
             viralLoadConcept,
             location,
             oneYearBefore,
-            context.getNow(),
+            onOrBefore,
             cohort,
             context);
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/PregnantDateCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/PregnantDateCalculation.java
@@ -48,7 +48,8 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
     CalculationResultMap resultMap = new CalculationResultMap();
 
     Location location = (Location) context.getFromCache("location");
-    Date oneYearBefore = EptsCalculationUtils.addMonths(context.getNow(), -12);
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    Date oneYearBefore = EptsCalculationUtils.addMonths(onOrBefore, -12);
 
     EncounterType labEncounterType = hivMetadata.getMisauLaboratorioEncounterType();
     EncounterType adultFollowup = hivMetadata.getAdultoSeguimentoEncounterType();
@@ -106,7 +107,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
             viralLoadConcept,
             location,
             oneYearBefore,
-            context.getNow(),
+            onOrBefore,
             femaleCohort,
             context);
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/RoutineCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/RoutineCalculation.java
@@ -70,7 +70,8 @@ public class RoutineCalculation extends AbstractPatientCalculation {
     Location location = (Location) context.getFromCache("location");
     Concept viralLoadConcept = hivMetadata.getHivViralLoadConcept();
     Concept regimeConcept = hivMetadata.getRegimeConcept();
-    Date latestVlLowerDateLimit = EptsCalculationUtils.addMonths(context.getNow(), -12);
+    Date onOrBefore = (Date) context.getFromCache("onOrBefore");
+    Date latestVlLowerDateLimit = EptsCalculationUtils.addMonths(onOrBefore, -12);
 
     // limits the number of obs we are calling up
     Date allVlLowerDateLimit =
@@ -113,7 +114,7 @@ public class RoutineCalculation extends AbstractPatientCalculation {
             viralLoadConcept,
             location,
             latestVlLowerDateLimit,
-            context.getNow(),
+            onOrBefore,
             cohort,
             context);
 
@@ -141,14 +142,14 @@ public class RoutineCalculation extends AbstractPatientCalculation {
         // we do not consider if the patient's last VL obs is not within
         // window
         if (lastVlObs.getObsDatetime().after(latestVlLowerDateLimit)
-            && lastVlObs.getObsDatetime().before(context.getNow())) {
+            && lastVlObs.getObsDatetime().before(onOrBefore)) {
 
           // get all the VL results for each patient in the last 12 months
           ListResult vlObsResult = (ListResult) patientHavingVL.get(pId);
           List<Obs> vLoadList = EptsCalculationUtils.extractResultValues(vlObsResult);
           List<Obs> viralLoadForPatientTakenWithin12Months =
               getViralLoadForPatientTakenWithin12Months(
-                  context.getNow(), latestVlLowerDateLimit, vLoadList);
+                  onOrBefore, latestVlLowerDateLimit, vLoadList);
 
           // find out for criteria 1 a
           // the patients should be 6 to 9 months after ART initiation
@@ -270,13 +271,13 @@ public class RoutineCalculation extends AbstractPatientCalculation {
   }
 
   private List<Obs> getViralLoadForPatientTakenWithin12Months(
-      Date now, Date latestVlLowerDateLimit, List<Obs> vLoadList) {
+      Date onOrBefore, Date latestVlLowerDateLimit, List<Obs> vLoadList) {
     List<Obs> viralLoadForPatientTakenWithin12Months = new ArrayList<>();
     // populate viralLoadForPatientTakenWithin12Months with obs which fall within the 12month window
     for (Obs obs : vLoadList) {
       if (obs != null
           && obs.getObsDatetime().after(latestVlLowerDateLimit)
-          && obs.getObsDatetime().before(now)) {
+          && obs.getObsDatetime().before(onOrBefore)) {
         viralLoadForPatientTakenWithin12Months.add(obs);
       }
     }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/cohort/definition/CalculationCohortDefinition.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/cohort/definition/CalculationCohortDefinition.java
@@ -33,7 +33,10 @@ public class CalculationCohortDefinition extends BaseCohortDefinition {
   private PatientCalculation calculation;
 
   @ConfigurationProperty(group = "calculation")
-  private Date onDate;
+  private Date onOrAfter;
+
+  @ConfigurationProperty(group = "calculation")
+  private Date onOrBefore;
 
   @ConfigurationProperty(group = "calculation")
   private Object withResult;
@@ -80,22 +83,30 @@ public class CalculationCohortDefinition extends BaseCohortDefinition {
     this.calculation = calculation;
   }
 
+  public Date getOnOrAfter() {
+    return onOrAfter;
+  }
+
+  public void setOnOrAfter(Date onOrAfter) {
+    this.onOrAfter = onOrAfter;
+  }
+
   /**
    * Gets the date for which to calculate
    *
    * @return the date
    */
-  public Date getOnDate() {
-    return onDate;
+  public Date getOnOrBefore() {
+    return onOrBefore;
   }
 
   /**
    * Sets the date for which to calculate
    *
-   * @param onDate the date
+   * @param onOrBefore the date
    */
-  public void setOnDate(Date onDate) {
-    this.onDate = onDate;
+  public void setOnOrBefore(Date onOrBefore) {
+    this.onOrBefore = onOrBefore;
   }
 
   /**

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/cohort/evaluator/CalculationCohortDefinitionEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/cohort/evaluator/CalculationCohortDefinitionEvaluator.java
@@ -13,10 +13,8 @@
  */
 package org.openmrs.module.eptsreports.reporting.cohort.evaluator;
 
-import java.util.Date;
 import java.util.Set;
 import org.openmrs.Cohort;
-import org.openmrs.Location;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.calculation.patient.PatientCalculationContext;
@@ -63,25 +61,11 @@ public class CalculationCohortDefinitionEvaluator implements CohortDefinitionEva
       CohortDefinition cohortDefinition, EvaluationContext context) {
     CalculationCohortDefinition cd = (CalculationCohortDefinition) cohortDefinition;
 
-    // Use date from cohort definition, or from ${date} or ${endDate} or now
-    Date onDate = cd.getOnDate();
-    if (onDate == null) {
-      onDate = (Date) context.getParameterValue("date");
-      if (onDate == null) {
-        onDate = (Date) context.getParameterValue("endDate");
-        if (onDate == null) {
-          onDate = new Date();
-        }
-      }
-    }
-    Location location = cd.getLocation();
-
     PatientCalculationService pcs = Context.getService(PatientCalculationService.class);
     PatientCalculationContext calcContext = pcs.createCalculationContext();
-    calcContext.setNow(onDate);
-    calcContext.addToCache("location", location);
-    calcContext.addToCache("onOrAfter", context.getParameterValue("onOrAfter"));
-    calcContext.addToCache("onOrBefore", context.getParameterValue("onOrBefore"));
+    calcContext.addToCache("location", cd.getLocation());
+    calcContext.addToCache("onOrAfter", cd.getOnOrAfter());
+    calcContext.addToCache("onOrBefore", cd.getOnOrBefore());
 
     Cohort cohort = context.getBaseCohort();
     if (cohort == null) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TxPvlsCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TxPvlsCohortQueries.java
@@ -45,7 +45,7 @@ public class TxPvlsCohortQueries {
         new CalculationCohortDefinition(
             "On ART for at least 3 months",
             Context.getRegisteredComponents(OnArtForMoreThanXmonthsCalcultion.class).get(0));
-    cd.addParameter(new Parameter("onDate", "On Date", Date.class));
+    cd.addParameter(new Parameter("onOrBefore", "On or before Date", Date.class));
     cd.addParameter(new Parameter("location", "Location", Location.class));
     return cd;
   }
@@ -68,7 +68,7 @@ public class TxPvlsCohortQueries {
         EptsReportUtils.map(
             getPatientsWhoArePregnantOrBreastfeedingBasedOnParameter(
                 PregnantOrBreastfeedingWomen.BREASTFEEDINGWOMEN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
 
     cd.addSearch(
         "suppression",
@@ -98,7 +98,7 @@ public class TxPvlsCohortQueries {
         EptsReportUtils.map(
             getPatientsWhoArePregnantOrBreastfeedingBasedOnParameter(
                 PregnantOrBreastfeedingWomen.BREASTFEEDINGWOMEN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
 
     cd.addSearch(
         "results",
@@ -127,7 +127,7 @@ public class TxPvlsCohortQueries {
     cd.addSearch(
         "onArtLongEnough",
         EptsReportUtils.map(
-            getPatientsWhoAreMoreThan3MonthsOnArt(), "onDate=${endDate},location=${location}"));
+            getPatientsWhoAreMoreThan3MonthsOnArt(), "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("supp AND onArtLongEnough");
     return cd;
   }
@@ -148,7 +148,7 @@ public class TxPvlsCohortQueries {
     cd.addSearch(
         "onArtLongEnough",
         EptsReportUtils.map(
-            getPatientsWhoAreMoreThan3MonthsOnArt(), "onDate=${endDate},location=${location}"));
+            getPatientsWhoAreMoreThan3MonthsOnArt(), "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("results AND onArtLongEnough");
     return cd;
   }
@@ -163,7 +163,7 @@ public class TxPvlsCohortQueries {
         new CalculationCohortDefinition(
             "criteria", Context.getRegisteredComponents(RoutineCalculation.class).get(0));
     cd.setName("Routine for all patients controlled by parameter");
-    cd.addParameter(new Parameter("onDate", "On Date", Date.class));
+    cd.addParameter(new Parameter("onOrBefore", "On or before Date", Date.class));
     cd.addParameter(new Parameter("location", "Location", Location.class));
     cd.addCalculationParameter("criteria", criteria);
     return cd;
@@ -186,7 +186,7 @@ public class TxPvlsCohortQueries {
         "adult-children-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.ADULTCHILDREN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("supp AND adult-children-routine");
     return cd;
   }
@@ -209,7 +209,7 @@ public class TxPvlsCohortQueries {
         "adult-children-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.ADULTCHILDREN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("supp NOT adult-children-routine");
     return cd;
   }
@@ -231,7 +231,7 @@ public class TxPvlsCohortQueries {
         "adult-children-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.ADULTCHILDREN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("results AND adult-children-routine");
     return cd;
   }
@@ -253,7 +253,7 @@ public class TxPvlsCohortQueries {
         "adult-children-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.ADULTCHILDREN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("results NOT adult-children-routine");
     return cd;
   }
@@ -280,7 +280,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("breastfeedingVl AND breastfeeding-routine");
 
     return cd;
@@ -306,7 +306,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("breastfeedingVl NOT breastfeeding-routine");
 
     return cd;
@@ -331,7 +331,7 @@ public class TxPvlsCohortQueries {
         EptsReportUtils.map(
             this.getPatientsWhoArePregnantOrBreastfeedingBasedOnParameter(
                 PregnantOrBreastfeedingWomen.PREGNANTWOMEN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("suppression AND pregnant");
     return cd;
   }
@@ -354,7 +354,7 @@ public class TxPvlsCohortQueries {
         EptsReportUtils.map(
             this.getPatientsWhoArePregnantOrBreastfeedingBasedOnParameter(
                 PregnantOrBreastfeedingWomen.PREGNANTWOMEN),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("results AND pregnant");
     return cd;
   }
@@ -379,7 +379,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("pregnant AND breastfeeding-routine");
     return cd;
   }
@@ -404,7 +404,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("pregnant NOT breastfeeding-routine");
     return cd;
   }
@@ -431,7 +431,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("vlandBreastfeeding AND breastfeeding-routine");
     return cd;
   }
@@ -456,7 +456,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("vlandBreastfeeding NOT breastfeeding-routine");
     return cd;
   }
@@ -481,7 +481,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("pregnant AND breastfeeding-routine");
     return cd;
   }
@@ -505,7 +505,7 @@ public class TxPvlsCohortQueries {
         "breastfeeding-routine",
         EptsReportUtils.map(
             getPatientsWhoAreOnRoutine(PatientsOnRoutineEnum.BREASTFEEDINGPREGNANT),
-            "onDate=${endDate},location=${location}"));
+            "onOrBefore=${endDate},location=${location}"));
     cd.setCompositionString("pregnant NOT breastfeeding-routine");
     return cd;
   }
@@ -521,7 +521,7 @@ public class TxPvlsCohortQueries {
         new CalculationCohortDefinition(
             "pregnantBreastfeeding",
             Context.getRegisteredComponents(BreastfeedingPregnantCalculation.class).get(0));
-    cd.addParameter(new Parameter("onDate", "On Date", Date.class));
+    cd.addParameter(new Parameter("onOrBefore", "On or before Date", Date.class));
     cd.addParameter(new Parameter("location", "Location", Location.class));
     cd.addCalculationParameter("state", state);
 

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/BasePatientCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/BasePatientCalculationTest.java
@@ -43,7 +43,7 @@ public abstract class BasePatientCalculationTest extends BaseModuleContextSensit
 
     Map<String, Object> cacheEntries = new HashMap<String, Object>();
     cacheEntries.put("location", Context.getLocationService().getLocation(1));
-    setEvaluationContext(testsHelper.getDate("2019-05-30 00:00:00.0"));
+    cacheEntries.put("onOrBefore", testsHelper.getDate("2019-05-30 00:00:00.0"));
     setEvaluationContext(cacheEntries);
 
     executeDataSet("calculationsTest.xml");

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/generic/StartedArtBeforeDateCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/generic/StartedArtBeforeDateCalculationTest.java
@@ -82,6 +82,7 @@ public class StartedArtBeforeDateCalculationTest extends BasePatientCalculationT
   public void shouldRaiseExceptionIfBeforeDateIsNotSpecified() {
     Map<String, Object> parameterValues = new HashMap<String, Object>();
     PatientCalculationContext context = getEvaluationContext();
+    context.removeFromCache("onOrBefore");
     final int patientId = 1777006;
     service.evaluate(Arrays.asList(patientId), getCalculation(), parameterValues, context);
   }

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/generic/StartedArtOnPeriodCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/generic/StartedArtOnPeriodCalculationTest.java
@@ -87,6 +87,7 @@ public class StartedArtOnPeriodCalculationTest extends BasePatientCalculationTes
     Calendar calendar = DateUtils.truncate(Calendar.getInstance(), Calendar.DAY_OF_MONTH);
     calendar.set(2008, Calendar.AUGUST, 1);
     context.addToCache("onOrAfter", calendar.getTime());
+    context.removeFromCache("onOrBefore");
     final int patientId = 1777001;
     service.evaluate(Arrays.asList(patientId), getCalculation(), parameterValues, context);
   }

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/pvls/BreastfeedingPregnantCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/pvls/BreastfeedingPregnantCalculationTest.java
@@ -2,6 +2,8 @@ package org.openmrs.module.eptsreports.reporting.intergrated.calculation.pvls;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,7 +68,9 @@ public class BreastfeedingPregnantCalculationTest extends BasePatientCalculation
 
   @Test
   public void shouldReturnBreastfeedingIfMostRecent() {
-    setEvaluationContext(testsHelper.getDate("2018-09-20 00:00:00.0"));
+    HashMap<String, Object> cacheEntries = new HashMap<>();
+    cacheEntries.put("onOrBefore", testsHelper.getDate("2018-09-20 00:00:00.0"));
+    setEvaluationContext(cacheEntries);
     params.put("state", PregnantOrBreastfeedingWomen.BREASTFEEDINGWOMEN);
 
     CalculationResultMap evaluatedResult =

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/pvls/BreastfeedingPregnantCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/pvls/BreastfeedingPregnantCalculationTest.java
@@ -2,7 +2,6 @@ package org.openmrs.module.eptsreports.reporting.intergrated.calculation.pvls;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import org.junit.Assert;
 import org.junit.Before;

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/unit/calculation/pvls/RoutineCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/unit/calculation/pvls/RoutineCalculationTest.java
@@ -307,7 +307,7 @@ public class RoutineCalculationTest extends BaseContextMockTest {
     PatientCalculationContext calculationContext =
         patientCalculationService.createCalculationContext();
     calculationContext.addToCache("location", location);
-    calculationContext.setNow(now);
+    calculationContext.addToCache("onOrBefore", now);
 
     Collection<Integer> cohort = Arrays.asList(patient.getId());
 

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/unit/cohort/evaluator/CalculationCohortDefinitionEvaluatorTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/unit/cohort/evaluator/CalculationCohortDefinitionEvaluatorTest.java
@@ -1,13 +1,11 @@
 package org.openmrs.module.eptsreports.reporting.unit.cohort.evaluator;
 
-import static junit.framework.TestCase.fail;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.*;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -91,52 +89,6 @@ public class CalculationCohortDefinitionEvaluatorTest extends BaseContextMockTes
   }
 
   @Test
-  public void evaluateShouldSetContextNowToDateFromOnDate() throws EvaluationException {
-    Date date = testsHelper.getDate("2018-04-10 00:00:00.0");
-    definition.setOnDate(date);
-    PatientCalculationContext calculationContext =
-        patientCalculationService.createCalculationContext();
-    EvaluationContext context = new EvaluationContext();
-    context.setBaseCohort(new PatientIdSet());
-    when(patientCalculationService.createCalculationContext()).thenReturn(calculationContext);
-    evaluator.evaluate(definition, context);
-    Assert.assertEquals(calculationContext.getNow(), date);
-  }
-
-  @Test
-  public void evaluateShouldSetContextNowToDateFromDateParameter() throws EvaluationException {
-    Date date = testsHelper.getDate("2018-04-10 00:00:00.0");
-    PatientCalculationContext calculationContext =
-        patientCalculationService.createCalculationContext();
-    EvaluationContext context = new EvaluationContext();
-    context.setBaseCohort(new PatientIdSet());
-    context.addParameterValue("date", date);
-    when(patientCalculationService.createCalculationContext()).thenReturn(calculationContext);
-    evaluator.evaluate(definition, context);
-    Assert.assertEquals(calculationContext.getNow(), date);
-  }
-
-  @Test
-  public void evaluateShouldSetContextNowToDateFromEndDateParameter() throws EvaluationException {
-    Date date = testsHelper.getDate("2018-04-10 00:00:00.0");
-    PatientCalculationContext calculationContext =
-        patientCalculationService.createCalculationContext();
-    EvaluationContext context = new EvaluationContext();
-    context.setBaseCohort(new PatientIdSet());
-    context.addParameterValue("endDate", date);
-    when(patientCalculationService.createCalculationContext()).thenReturn(calculationContext);
-    evaluator.evaluate(definition, context);
-    Assert.assertEquals(calculationContext.getNow(), date);
-  }
-
-  @Test
-  @Ignore
-  public void evaluateShouldSetContextNowToCurrentDate() {
-    fail("Not yet Implemented");
-    Assert.assertTrue(true);
-  }
-
-  @Test
   public void evaluateShouldAddLocationToContextCache() throws EvaluationException {
     Location location = new Location(1);
     definition.setLocation(location);
@@ -156,10 +108,10 @@ public class CalculationCohortDefinitionEvaluatorTest extends BaseContextMockTes
         patientCalculationService.createCalculationContext();
     EvaluationContext context = new EvaluationContext();
     context.setBaseCohort(new PatientIdSet());
-    context.addParameterValue("onOrAfter", date);
+    definition.setOnOrAfter(date);
     when(patientCalculationService.createCalculationContext()).thenReturn(calculationContext);
     evaluator.evaluate(definition, context);
-    Assert.assertEquals(calculationContext.getFromCache("onOrAfter"), date);
+    Assert.assertEquals(date, calculationContext.getFromCache("onOrAfter"));
   }
 
   @Test
@@ -169,7 +121,7 @@ public class CalculationCohortDefinitionEvaluatorTest extends BaseContextMockTes
         patientCalculationService.createCalculationContext();
     EvaluationContext context = new EvaluationContext();
     context.setBaseCohort(new PatientIdSet());
-    context.addParameterValue("onOrBefore", date);
+    definition.setOnOrBefore(date);
     when(patientCalculationService.createCalculationContext()).thenReturn(calculationContext);
     evaluator.evaluate(definition, context);
     Assert.assertEquals(calculationContext.getFromCache("onOrBefore"), date);


### PR DESCRIPTION
CalculationCohortDefinition

 * onDate parameter changed to onOrBefore

 * added onOrAfter parameter

CalculationCohortDefinitionEvaluator

 * removed usages of date, endDate and currentDate. using only onOrBefore

 * Using cache to store onOrBefore instead of property now from CalculationContext