### PR TITLE
MEPTS-353: Start and complete drugs should include ficha clinica, mastercard

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/metadata/HivMetadata.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/metadata/HivMetadata.java
@@ -558,7 +558,8 @@ public class HivMetadata extends ProgramsMetadata {
 
   // Concept 1256 Start Drugs
   public Concept getStartDrugs() {
-    String uuid = Context.getAdministrationService().getGlobalProperty("eptsreports.startDrugs");
+    String uuid =
+        Context.getAdministrationService().getGlobalProperty("eptsreports.startDrugsConceptUuid");
     return getConcept(uuid);
   }
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/common/EPTSCalculationService.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/common/EPTSCalculationService.java
@@ -80,6 +80,51 @@ public class EPTSCalculationService {
   }
 
   /**
+   * Evaluate for obs based on the time modifier
+   *
+   * @param concept
+   * @param encounterTypes
+   * @param cohort
+   * @param locationList
+   * @param valueCodedList
+   * @param timeQualifier
+   * @param startDate
+   * @param context
+   * @return
+   */
+  public CalculationResultMap getObs(
+      Concept concept,
+      List<EncounterType> encounterTypes,
+      Collection<Integer> cohort,
+      List<Location> locationList,
+      List<Concept> valueCodedList,
+      TimeQualifier timeQualifier,
+      Date startDate,
+      Date endDate,
+      PatientCalculationContext context) {
+    ObsForPersonDataDefinition def = new ObsForPersonDataDefinition();
+    def.setName(timeQualifier.name() + "obs");
+    def.setWhich(timeQualifier);
+    def.setQuestion(concept);
+    if (encounterTypes != null) {
+      def.setEncounterTypeList(encounterTypes);
+    }
+    if (startDate != null) {
+      def.setOnOrAfter(startDate);
+    }
+    if (endDate != null) {
+      def.setOnOrBefore(endDate);
+    }
+    if (valueCodedList != null && !valueCodedList.isEmpty()) {
+      def.setValueCodedList(valueCodedList);
+    }
+    if (!locationList.isEmpty()) {
+      def.setLocationList(locationList);
+    }
+    return EptsCalculationUtils.evaluateWithReporting(def, cohort, null, null, context);
+  }
+
+  /**
    * Evaluates the last patient state for the specified programWorkflowState
    *
    * @param cohort

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
@@ -71,6 +71,8 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
 
     Date onOrBefore = (Date) context.getFromCache(ON_OR_BEFORE);
     Date onOrAfter = (Date) context.getFromCache(ON_OR_AFTER);
+    
+    
 
     if (onOrAfter != null && onOrBefore != null) {
       Date beginPeriodStartDate =
@@ -158,30 +160,54 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
 
         Date earliestDate = null;
         Date latestDate = null;
+        
+        
+        /*
+         * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
+         * and enddate of the old spec is not null and the enddate of the new spec is null
+         */
 
         if ((startDate != null && startDrugsObs == null)
             && (endDate != null && endDrugsObs == null)) {
           earliestDate = startDate;
           latestDate = endDate;
         }
+        
+        /*
+         * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
+         * and enddate of the old spec is  null and the enddate of the new spec is not  null
+         */
 
         if ((startDate != null && startDrugsObs == null)
             && (endDate == null && endDrugsObs != null)) {
           earliestDate = startDate;
           latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
         }
+        
+        /*
+         * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
+         * and enddate of the old spec is not null and the enddate of the new spec is   null
+         */
         if ((startDate == null && startDrugsObs != null)
             && (endDate != null && endDrugsObs == null)) {
           earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
           latestDate = endDate;
         }
+        
+        /*
+         * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
+         * and enddate of the old spec is  null and the enddate of the new spec is  not null
+         */
 
         if ((startDate == null && startDrugsObs != null)
             && (endDate == null && endDrugsObs != null)) {
           earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
           latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
         }
-
+        /*
+         * Assuming that the 2 startdates are not null  and the old spec enddate  is not null
+         * for the startdates we pick the earliest  
+         */
         if ((startDate != null && startDrugsObs != null)
             && (endDate != null && endDrugsObs == null)) {
           if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
@@ -191,6 +217,10 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
           }
           latestDate = endDate;
         }
+        /*
+         * Assuming that the 2 startdates are not null  and the new spec enddate  is not null
+         * for the startdates we pick the earliest  
+         */
         if ((startDate != null && startDrugsObs != null)
             && (endDate == null && endDrugsObs != null)) {
           if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
@@ -200,7 +230,10 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
           }
           latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
         }
-
+        /*
+         * Assuming that the 2 enddates are not null  and the old spec startdate  is not null
+         * for the enddates we pick the latest  
+         */
         if ((startDate != null && startDrugsObs == null)
             && (endDate != null && endDrugsObs != null)) {
           if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
@@ -210,7 +243,10 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
           }
           earliestDate = startDate;
         }
-
+        /*
+         * Assuming that the 2 enddates are not null  and the new spec startdate  is not null
+         * for the enddates we pick the latest  
+         */
         if ((startDate == null && startDrugsObs != null)
             && (endDate != null && endDrugsObs != null)) {
           if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
@@ -220,7 +256,11 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
           }
           earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
         }
-
+        
+        /*
+         * Assuming that the 2 startdate and the 2 and dates are not null
+         * for the startdate we pick the earliest and for the   last date we pick the  latest
+         */
         if ((startDate != null && startDrugsObs != null)
             && (endDate != null && endDrugsObs != null)) {
           // get the earliest
@@ -237,7 +277,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
             latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
           }
         }
-
+        // if no  earliestDate and  latestDate is picked the the patient is skipped 
         if (earliestDate == null && latestDate == null) {
           continue;
         }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
@@ -71,8 +71,6 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
 
     Date onOrBefore = (Date) context.getFromCache(ON_OR_BEFORE);
     Date onOrAfter = (Date) context.getFromCache(ON_OR_AFTER);
-    
-    
 
     if (onOrAfter != null && onOrBefore != null) {
       Date beginPeriodStartDate =
@@ -157,16 +155,18 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
         boolean inconsistent =
             (startDate != null && endDate != null && startDate.compareTo(endDate) > 0)
                 || (startDate == null && endDate != null);
-        
-       Date [] dateBoundaries =  evaluateEarliestDateAndLatestDate(startDate, startDrugsObs, endDate, endDrugsObs);
-        
-        // if no  earliestDate and  latestDate is picked the the patient is skipped 
-        if (dateBoundaries[0] == null && dateBoundaries[1]  == null) {
+
+        Date[] dateBoundaries =
+            evaluateEarliestDateAndLatestDate(startDate, startDrugsObs, endDate, endDrugsObs);
+
+        // if no  earliestDate and  latestDate is picked the the patient is skipped
+        if (dateBoundaries[0] == null && dateBoundaries[1] == null) {
           continue;
         }
 
         int profilaxiaDuration12 =
-            Days.daysIn(new Interval(dateBoundaries[0].getTime(), dateBoundaries[1].getTime())).getDays();
+            Days.daysIn(new Interval(dateBoundaries[0].getTime(), dateBoundaries[1].getTime()))
+                .getDays();
 
         if (profilaxiaDuration12 >= MINIMUM_DURATION_IN_DAYS) {
           map.put(patientId, new BooleanResult(true, this));
@@ -211,132 +211,119 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
     }
     return null;
   }
-  private  Date [] evaluateEarliestDateAndLatestDate(
-		  Date startDate, 
-		  Obs startDrugsObs, 
-		  Date endDate, 
-		  Obs endDrugsObs
-		 ) {
-	  
-	  Date earliestDate = null;
-      Date latestDate = null;
-	  /*
-         * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
-         * and enddate of the old spec is not null and the enddate of the new spec is null
-         */
 
-        if ((startDate != null && startDrugsObs == null)
-            && (endDate != null && endDrugsObs == null)) {
-          earliestDate = startDate;
-          latestDate = endDate;
-        }
-        
-        /*
-         * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
-         * and enddate of the old spec is  null and the enddate of the new spec is not  null
-         */
+  private Date[] evaluateEarliestDateAndLatestDate(
+      Date startDate, Obs startDrugsObs, Date endDate, Obs endDrugsObs) {
 
-        if ((startDate != null && startDrugsObs == null)
-            && (endDate == null && endDrugsObs != null)) {
-          earliestDate = startDate;
-          latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-        }
-        
-        /*
-         * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
-         * and enddate of the old spec is not null and the enddate of the new spec is   null
-         */
-        if ((startDate == null && startDrugsObs != null)
-            && (endDate != null && endDrugsObs == null)) {
-          earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-          latestDate = endDate;
-        }
-        
-        /*
-         * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
-         * and enddate of the old spec is  null and the enddate of the new spec is  not null
-         */
+    Date earliestDate = null;
+    Date latestDate = null;
+    /*
+     * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
+     * and enddate of the old spec is not null and the enddate of the new spec is null
+     */
 
-        if ((startDate == null && startDrugsObs != null)
-            && (endDate == null && endDrugsObs != null)) {
-          earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-          latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-        }
-        /*
-         * Assuming that the 2 startdates are not null  and the old spec enddate  is not null
-         * for the startdates we pick the earliest  
-         */
-        if ((startDate != null && startDrugsObs != null)
-            && (endDate != null && endDrugsObs == null)) {
-          if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-          } else {
-            earliestDate = startDate;
-          }
-          latestDate = endDate;
-        }
-        /*
-         * Assuming that the 2 startdates are not null  and the new spec enddate  is not null
-         * for the startdates we pick the earliest  
-         */
-        if ((startDate != null && startDrugsObs != null)
-            && (endDate == null && endDrugsObs != null)) {
-          if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-          } else {
-            earliestDate = startDate;
-          }
-          latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-        }
-        /*
-         * Assuming that the 2 enddates are not null  and the old spec startdate  is not null
-         * for the enddates we pick the latest  
-         */
-        if ((startDate != null && startDrugsObs == null)
-            && (endDate != null && endDrugsObs != null)) {
-          if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            latestDate = endDate;
-          } else {
-            latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-          }
-          earliestDate = startDate;
-        }
-        /*
-         * Assuming that the 2 enddates are not null  and the new spec startdate  is not null
-         * for the enddates we pick the latest  
-         */
-        if ((startDate == null && startDrugsObs != null)
-            && (endDate != null && endDrugsObs != null)) {
-          if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            latestDate = endDate;
-          } else {
-            latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-          }
-          earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-        }
-        
-        /*
-         * Assuming that the 2 startdate and the 2 and dates are not null
-         * for the startdate we pick the earliest and for the   last date we pick the  latest
-         */
-        if ((startDate != null && startDrugsObs != null)
-            && (endDate != null && endDrugsObs != null)) {
-          // get the earliest
-          if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
-          } else {
-            earliestDate = startDate;
-          }
-          // //get the latest
+    if ((startDate != null && startDrugsObs == null) && (endDate != null && endDrugsObs == null)) {
+      earliestDate = startDate;
+      latestDate = endDate;
+    }
 
-          if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
-            latestDate = endDate;
-          } else {
-            latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
-          }
-        }
-	  
-	  return new Date [] {earliestDate,latestDate};
-	  
+    /*
+     * Assuming that the  startdate of the old spec is not null and the startdate of the new spec is null
+     * and enddate of the old spec is  null and the enddate of the new spec is not  null
+     */
+
+    if ((startDate != null && startDrugsObs == null) && (endDate == null && endDrugsObs != null)) {
+      earliestDate = startDate;
+      latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+    }
+
+    /*
+     * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
+     * and enddate of the old spec is not null and the enddate of the new spec is   null
+     */
+    if ((startDate == null && startDrugsObs != null) && (endDate != null && endDrugsObs == null)) {
+      earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+      latestDate = endDate;
+    }
+
+    /*
+     * Assuming that the  startdate of the old spec is  null and the startdate of the new spec is not null
+     * and enddate of the old spec is  null and the enddate of the new spec is  not null
+     */
+
+    if ((startDate == null && startDrugsObs != null) && (endDate == null && endDrugsObs != null)) {
+      earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+      latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+    }
+    /*
+     * Assuming that the 2 startdates are not null  and the old spec enddate  is not null
+     * for the startdates we pick the earliest
+     */
+    if ((startDate != null && startDrugsObs != null) && (endDate != null && endDrugsObs == null)) {
+      if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+      } else {
+        earliestDate = startDate;
+      }
+      latestDate = endDate;
+    }
+    /*
+     * Assuming that the 2 startdates are not null  and the new spec enddate  is not null
+     * for the startdates we pick the earliest
+     */
+    if ((startDate != null && startDrugsObs != null) && (endDate == null && endDrugsObs != null)) {
+      if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+      } else {
+        earliestDate = startDate;
+      }
+      latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+    }
+    /*
+     * Assuming that the 2 enddates are not null  and the old spec startdate  is not null
+     * for the enddates we pick the latest
+     */
+    if ((startDate != null && startDrugsObs == null) && (endDate != null && endDrugsObs != null)) {
+      if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        latestDate = endDate;
+      } else {
+        latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+      }
+      earliestDate = startDate;
+    }
+    /*
+     * Assuming that the 2 enddates are not null  and the new spec startdate  is not null
+     * for the enddates we pick the latest
+     */
+    if ((startDate == null && startDrugsObs != null) && (endDate != null && endDrugsObs != null)) {
+      if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        latestDate = endDate;
+      } else {
+        latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+      }
+      earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+    }
+
+    /*
+     * Assuming that the 2 startdate and the 2 and dates are not null
+     * for the startdate we pick the earliest and for the   last date we pick the  latest
+     */
+    if ((startDate != null && startDrugsObs != null) && (endDate != null && endDrugsObs != null)) {
+      // get the earliest
+      if (startDate.compareTo(startDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        earliestDate = startDrugsObs.getEncounter().getEncounterDatetime();
+      } else {
+        earliestDate = startDate;
+      }
+      // //get the latest
+
+      if (endDate.compareTo(endDrugsObs.getEncounter().getEncounterDatetime()) > 0) {
+        latestDate = endDate;
+      } else {
+        latestDate = endDrugsObs.getEncounter().getEncounterDatetime();
+      }
+    }
+
+    return new Date[] {earliestDate, latestDate};
   }
 }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
@@ -230,7 +230,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
     return null;
   }
   /**
-   * @param a The start drugs or end drugs Obs from from Ficha de Seguimento (adults and children)
+   * @param a The start drugs or end drugs Obs from Ficha de Seguimento (adults and children)
    *     or Ficha Resumo
    * @param b The start drugs or end drugs Obs from from Ficha Clinica-MasterCard
    * @param priority MIN to retrieve the start drugs date, MAX to retrieve the end drugs date

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
@@ -104,7 +104,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
               cohort,
               Arrays.asList(location),
               Arrays.asList(hivMetadata.getStartDrugs()),
-              TimeQualifier.ANY,
+              TimeQualifier.FIRST,
               beginPeriodStartDate,
               beginPeriodEndDate,
               context);
@@ -125,7 +125,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
               cohort,
               Arrays.asList(location),
               Arrays.asList(hivMetadata.getCompletedConcept()),
-              TimeQualifier.ANY,
+              TimeQualifier.LAST,
               beginPeriodStartDate,
               beginPeriodEndDate,
               context);

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
@@ -40,7 +40,7 @@ public class TbPrevCohortQueries {
   @Autowired private HivMetadata hivMetadata;
 
   @Autowired private GenericCohortQueries genericCohortQueries;
-  
+
   @Autowired private HivCohortQueries hivCohortQueries;
 
   public CohortDefinition getPatientsThatStartedProfilaxiaIsoniazidaOnPeriod() {
@@ -142,15 +142,15 @@ public class TbPrevCohortQueries {
             getPatientsThatStartedProfilaxiaIsoniazidaOnPeriod(),
             "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.addSearch(
-            "initiated-profilaxia",
-            EptsReportUtils.map(
-            		getPatientsThatInitiatedProfilaxia(),
-                "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
+        "initiated-profilaxia",
+        EptsReportUtils.map(
+            getPatientsThatInitiatedProfilaxia(),
+            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.addSearch(
         "transferred-out",
         EptsReportUtils.map(
-                hivCohortQueries.getPatientsTransferredOut(),
-                "onOrBefore=${onOrBefore},location=${location}"));
+            hivCohortQueries.getPatientsTransferredOut(),
+            "onOrBefore=${onOrBefore},location=${location}"));
     definition.addSearch(
         "completed-isoniazid",
         EptsReportUtils.map(
@@ -172,30 +172,28 @@ public class TbPrevCohortQueries {
     cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     return cd;
   }
-  
-	/**
-	 * Patients who on “Ficha Clinica-MasterCard”, mastercard under “
-	 * Profilaxia INH” were marked with an “I” (inicio) in a clinical consultation
-	 * date occurred between ${onOrAfter} and ${onOrBefore}
-	 * 
-	 * @return the cohort definition
-	 */
+
+  /**
+   * Patients who on “Ficha Clinica-MasterCard”, mastercard under “ Profilaxia INH” were marked with
+   * an “I” (inicio) in a clinical consultation date occurred between ${onOrAfter} and ${onOrBefore}
+   *
+   * @return the cohort definition
+   */
   public CohortDefinition getPatientsThatInitiatedProfilaxia() {
-      Concept profilaxiaINH = hivMetadata.getIsoniazidUsageConcept();
-      Concept inicio = hivMetadata.getStartDrugs();
-      EncounterType adultoSeguimentoEncounterType = hivMetadata.getAdultoSeguimentoEncounterType();
+    Concept profilaxiaINH = hivMetadata.getIsoniazidUsageConcept();
+    Concept inicio = hivMetadata.getStartDrugs();
+    EncounterType adultoSeguimentoEncounterType = hivMetadata.getAdultoSeguimentoEncounterType();
 
-      CodedObsCohortDefinition cd = new CodedObsCohortDefinition();
-      cd.setName("Initiated Profilaxia");
-      cd.addParameter(new Parameter("location", "Location", Location.class));
-      cd.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
-      cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
-      cd.setEncounterTypeList(Collections.singletonList(adultoSeguimentoEncounterType));
-      cd.setTimeModifier(TimeModifier.ANY);
-      cd.setQuestion(profilaxiaINH);
-      cd.setValueList(Collections.singletonList(inicio));
-      cd.setOperator(SetComparator.IN);
-      return cd;
+    CodedObsCohortDefinition cd = new CodedObsCohortDefinition();
+    cd.setName("Initiated Profilaxia");
+    cd.addParameter(new Parameter("location", "Location", Location.class));
+    cd.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
+    cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
+    cd.setEncounterTypeList(Collections.singletonList(adultoSeguimentoEncounterType));
+    cd.setTimeModifier(TimeModifier.ANY);
+    cd.setQuestion(profilaxiaINH);
+    cd.setValueList(Collections.singletonList(inicio));
+    cd.setOperator(SetComparator.IN);
+    return cd;
   }
-
 }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
@@ -60,9 +60,9 @@ public class SetupMERSemiAnnualReport extends EptsDataExportManager {
     rd.setName(getName());
     rd.setDescription(getDescription());
     rd.setParameters(txMlDataset.getParameters());
-    // rd.addDataSetDefinition("TXML",
-    // Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
-    // rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
+    rd.addDataSetDefinition("TXML",
+    Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
+    rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
     rd.addDataSetDefinition("TBPREV", Mapped.mapStraightThrough(tbPrevDataset.constructDatset()));
     // add a base cohort to the report
     rd.setBaseCohortDefinition(

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
@@ -60,8 +60,9 @@ public class SetupMERSemiAnnualReport extends EptsDataExportManager {
     rd.setName(getName());
     rd.setDescription(getDescription());
     rd.setParameters(txMlDataset.getParameters());
-    rd.addDataSetDefinition("TXML", Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
-    rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
+    // rd.addDataSetDefinition("TXML",
+    // Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
+    // rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
     rd.addDataSetDefinition("TBPREV", Mapped.mapStraightThrough(tbPrevDataset.constructDatset()));
     // add a base cohort to the report
     rd.setBaseCohortDefinition(

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
@@ -60,8 +60,7 @@ public class SetupMERSemiAnnualReport extends EptsDataExportManager {
     rd.setName(getName());
     rd.setDescription(getDescription());
     rd.setParameters(txMlDataset.getParameters());
-    rd.addDataSetDefinition("TXML",
-    Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
+    rd.addDataSetDefinition("TXML", Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
     rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
     rd.addDataSetDefinition("TBPREV", Mapped.mapStraightThrough(tbPrevDataset.constructDatset()));
     // add a base cohort to the report

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculationTest.java
@@ -97,7 +97,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculationTest
   }
 
   @Test
-  public void shouldBeTrueIfDoesNotHaveEndDateButAnsweredYesEnoughTimes() {
+  public void shouldBeFalseIfDoesNotHaveEndDateButAnsweredYesEnoughTimes() {
     Map<String, Object> parameterValues = new HashMap<String, Object>();
     PatientCalculationContext context = getEvaluationContext();
     Calendar calendar = DateUtils.truncate(Calendar.getInstance(), Calendar.DAY_OF_MONTH);
@@ -110,7 +110,6 @@ public class CompletedIsoniazidProphylaticTreatmentCalculationTest
     CalculationResultMap results =
         service.evaluate(Arrays.asList(patientId), getCalculation(), parameterValues, context);
     BooleanResult result = (BooleanResult) results.get(patientId);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(Boolean.TRUE, result.getValue());
+    Assert.assertNull(result);
   }
 }

--- a/api/src/test/resources/calculationsTest.xml
+++ b/api/src/test/resources/calculationsTest.xml
@@ -189,6 +189,9 @@
 	<concept concept_id="23865" retired="0" datatype_id="2" class_id="7" is_set="0" creator="1" date_created="2019-07-09 12:53:56" changed_by="1" date_changed="2019-07-09 12:53:56" uuid="e07fb227-7a5a-4edf-93e8-7633c9fd1ea0" />
 	<concept_name concept_id="23865" name="ART PICKUP" locale="en" creator="1" date_created="2019-07-09 12:53:56" concept_name_id="33689" voided="0" uuid="02dd0763-2269-431d-8531-fe438c15d0a1" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" />
 
+	<concept concept_id="1267" retired="false" datatype_id="11" class_id="3" is_set="false" creator="1" date_created="2019-01-29 00:00:00.0" version="0.1" changed_by="1" date_changed="2019-01-29 14:57:33.0" uuid="e1d9facc-1d5f-11e0-b929-000c29ad1d07"/>
+	<concept_name concept_name_id="1267" concept_id="1267" name="COMPLETED" locale="en_GB" creator="1" date_created="2019-01-29 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="e2405c04-1d5f-11e0-b929-000c29ad1d07"/>
+
 	<concept_set concept_set_id="8777008" concept_id="7777008" concept_set="7777007" sort_weight="1.0" creator="1" date_created="2019-01-29 12:38:58.0" uuid="fdefaa94-3f99-464c-8b1f-3e1d18777008"/>
 	<concept_set concept_set_id="8777009" concept_id="7777009" concept_set="7777007" sort_weight="1.0" creator="1" date_created="2019-01-29 12:38:58.0" uuid="fdefaa94-3f99-464c-8b1f-3e1d18777009"/>
 	<concept_set concept_set_id="8777010" concept_id="7777010" concept_set="7777007" sort_weight="1.0" creator="1" date_created="2019-01-29 12:38:58.0" uuid="fdefaa94-3f99-464c-8b1f-3e1d18777010"/>
@@ -231,6 +234,7 @@
 	<global_property property="eptsreports.artProgramUuid" property_value="efe2481f-9e75-4515-8d5a-86bfde2b5ad3" uuid="efe2481f-9e75-4515-8d5a-86bfde2b5ad3"/>
 	<global_property property="eptsreports.arvPlanConceptUuid" property_value="a09ab2c5-878e-4905-b25d-578417777002" uuid="a09ab2c5-878e-4905-b25d-578417777002"/>
 	<global_property property="eptsreports.startDrugsConceptUuid" property_value="a09ab2c5-878e-4905-b25d-578417777003" uuid="a09ab2c5-878e-4905-b25d-578417777003"/>
+	<global_property property="eptsreports.completedConceptUuid" property_value="e1d9facc-1d5f-11e0-b929-000c29ad1d07" uuid="ee89191a-d5ea-450f-9cf3-3eba99272055"/>
 	<global_property property="eptsreports.transferFromOtherFacilityConceptUuid" property_value="a09ab2c5-878e-4905-b25d-578417777004" uuid="a09ab2c5-878e-4905-b25d-578417777004"/>
 	<global_property property="eptsreports.historicalStartDateConceptUuid" property_value="a09ab2c5-878e-4905-b25d-578417777005" uuid="a09ab2c5-878e-4905-b25d-578417777005"/>
 	<global_property property="eptsreports.sTarvFarmaciaEncounterTypeUuid" property_value="02c533ab-b74b-4ee4-b6e5-ffb6d6777003" uuid="02c533ab-b74b-4ee4-b6e5-ffb6d6777003"/>


### PR DESCRIPTION
- I added #`getObs` method in `EPTSCalculationService`

- In `CompletedIsoniazidProphylaticTreatmentCalculation`, I added `CalculationResultMap` in `evaluate` method to get start drugs and complete drugs Obs

- I then added `if ((!inconsistent && startDate != null) || startDrugsObs != null)` and `if (completed || endDrugsObs != null)` checks to make  sure the obs are conciderd during evaluation.