### PR TITLE
MEPTS-379: Updated the denominator desegregation 

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -17,9 +17,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
 import org.joda.time.DateTime;
 import org.joda.time.Months;
-import org.openmrs.EncounterType;
 import org.openmrs.Location;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
@@ -82,11 +82,6 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             cohort,
             parameterValues,
             context);
-    final List<EncounterType> consultationEncounterTypes =
-        Arrays.asList(
-            hivMetadata.getAdultoSeguimentoEncounterType(),
-            hivMetadata.getARVPediatriaSeguimentoEncounterType(),
-            hivMetadata.getMasterCardEncounterType());
     CalculationResultMap startProfilaxiaObservations =
         ePTSCalculationService.firstObs(
             hivMetadata.getDataInicioProfilaxiaIsoniazidaConcept(),
@@ -95,7 +90,10 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             false,
             null,
             endDate,
-            consultationEncounterTypes,
+            Arrays.asList(
+                    hivMetadata.getAdultoSeguimentoEncounterType(),
+                    hivMetadata.getARVPediatriaSeguimentoEncounterType(),
+                    hivMetadata.getMasterCardEncounterType()),
             cohort,
             context);
     CalculationResultMap startDrugsObservations =

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -1,0 +1,182 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License Version
+ * 1.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ */
+package org.openmrs.module.eptsreports.reporting.calculation.generic;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.joda.time.DateTime;
+import org.joda.time.Months;
+import org.openmrs.EncounterType;
+import org.openmrs.Location;
+import org.openmrs.Obs;
+import org.openmrs.api.context.Context;
+import org.openmrs.calculation.patient.PatientCalculationContext;
+import org.openmrs.calculation.result.CalculationResultMap;
+import org.openmrs.module.eptsreports.metadata.HivMetadata;
+import org.openmrs.module.eptsreports.reporting.calculation.AbstractPatientCalculation;
+import org.openmrs.module.eptsreports.reporting.calculation.BooleanResult;
+import org.openmrs.module.eptsreports.reporting.calculation.common.EPTSCalculationService;
+import org.openmrs.module.eptsreports.reporting.utils.EptsCalculationUtils;
+import org.openmrs.module.reporting.common.TimeQualifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Patients Newly Enrolled on ART: The patients from TB_PREV_DENOMINATOR (2 AND 3) who falls under
+ * “Patients Newly Enrolled on ART” are patients with the earliest IPT start Date (obtained based in
+ * different set of identified fields/sources defined in 3a) within 6 months of the earliest ART
+ * start Date (obtained based in different set of identified fields/sources defined in 2a): (Art
+ * Start Date minus IPT Start Date <= 6months)
+ *
+ * <p>Patients Previously Enrolled on ART: The patients from TB_PREV_DENOMINATOR (2 AND 3) who falls
+ * under “Patients Previously Enrolled on ART” are patients with the earliest TPI start Date
+ * (obtained based in different set of identified fields/sources defined in 3a) within 6 months of
+ * the earliest ART start Date (obtained based in different set of identified fields/sources defined
+ * in 2a): (Art Start Date minus TPI Start Date > 6months)
+ *
+ * @return a CulculationResultMap
+ */
+@Component
+public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCalculation {
+
+  private static final int MINIMUM_DURATION_IN_MONTHS = 6;
+
+  private static final String ON_OR_BEFORE = "onOrBefore";
+
+  @Autowired private HivMetadata hivMetadata;
+
+  @Autowired private EPTSCalculationService ePTSCalculationService;
+
+  @Override
+  public CalculationResultMap evaluate(
+      Collection<Integer> cohort,
+      Map<String, Object> parameterValues,
+      PatientCalculationContext context) {
+    CalculationResultMap map = new CalculationResultMap();
+    boolean isNewlyEnrolledOnArtSearch =
+        getBooleanParameter(parameterValues, "isNewlyEnrolledOnArtSearch");
+    Location location = (Location) context.getFromCache("location");
+    Date endDate = (Date) parameterValues.get(ON_OR_BEFORE);
+
+    if (endDate == null) {
+      endDate = (Date) context.getFromCache(ON_OR_BEFORE);
+    }
+
+    CalculationResultMap artStartDates =
+        calculate(
+            Context.getRegisteredComponents(InitialArtStartDateCalculation.class).get(0),
+            cohort,
+            parameterValues,
+            context);
+    final List<EncounterType> consultationEncounterTypes =
+        Arrays.asList(
+            hivMetadata.getAdultoSeguimentoEncounterType(),
+            hivMetadata.getARVPediatriaSeguimentoEncounterType(),
+            hivMetadata.getMasterCardEncounterType());
+    CalculationResultMap startProfilaxiaObservations =
+        ePTSCalculationService.firstObs(
+            hivMetadata.getDataInicioProfilaxiaIsoniazidaConcept(),
+            null,
+            location,
+            false,
+            null,
+            endDate,
+            consultationEncounterTypes,
+            cohort,
+            context);
+    CalculationResultMap startDrugsObservations =
+        ePTSCalculationService.getObs(
+            hivMetadata.getIsoniazidUsageConcept(),
+            Arrays.asList(hivMetadata.getAdultoSeguimentoEncounterType()),
+            cohort,
+            Arrays.asList(location),
+            Arrays.asList(hivMetadata.getStartDrugs()),
+            TimeQualifier.FIRST,
+            null,
+            endDate,
+            context);
+    if (endDate != null) {
+      for (Integer patientId : cohort) {
+        Date artStartDate =
+            InitialArtStartDateCalculation.getArtStartDate(patientId, artStartDates);
+        Obs seguimentoOrFichaResumo =
+            EptsCalculationUtils.resultForPatient(startProfilaxiaObservations, patientId);
+        Obs fichaClinicaMasterCardStartDrugsObs =
+            EptsCalculationUtils.resultForPatient(startDrugsObservations, patientId);
+        if ((seguimentoOrFichaResumo == null && fichaClinicaMasterCardStartDrugsObs == null)
+            || artStartDate == null) {
+          continue;
+        }
+        int artMinusIptStartDate =
+            Months.monthsBetween(
+                    new DateTime(artStartDate.getTime()),
+                    new DateTime(
+                        getEarliestIptStartDate(
+                                seguimentoOrFichaResumo, fichaClinicaMasterCardStartDrugsObs)
+                            .getTime()))
+                .getMonths();
+        if (artStartDate != null
+            && artStartDate.compareTo(endDate) <= 0
+            && artMinusIptStartDate <= MINIMUM_DURATION_IN_MONTHS
+            && isNewlyEnrolledOnArtSearch == true) {
+          map.put(patientId, new BooleanResult(true, this));
+        }
+        if (artStartDate != null
+            && artStartDate.compareTo(endDate) <= 0
+            && artMinusIptStartDate > MINIMUM_DURATION_IN_MONTHS
+            && isNewlyEnrolledOnArtSearch == false) {
+          map.put(patientId, new BooleanResult(true, this));
+        }
+      }
+      return map;
+    } else {
+      throw new IllegalArgumentException(String.format("Parameter %s must be set", ON_OR_BEFORE));
+    }
+  }
+
+  private Date getDateFromObs(Obs obs) {
+    if (obs != null) {
+      return obs.getValueDatetime();
+    }
+    return null;
+  }
+
+  private Date getEarliestIptStartDate(
+      Obs seguimentoOrFichaResumoDate, Obs fichaClinicaMasterCardDate) {
+    if (seguimentoOrFichaResumoDate != null && fichaClinicaMasterCardDate != null) {
+      List<Date> dates =
+          Arrays.asList(
+              getDateFromObs(seguimentoOrFichaResumoDate),
+              fichaClinicaMasterCardDate.getObsDatetime());
+      return Collections.min(dates);
+    } else {
+      return (getDateFromObs(seguimentoOrFichaResumoDate) != null)
+          ? getDateFromObs(seguimentoOrFichaResumoDate)
+          : fichaClinicaMasterCardDate.getObsDatetime();
+    }
+  }
+
+  private boolean getBooleanParameter(Map<String, Object> parameterValues, String parameterName) {
+    Boolean parameterValue = null;
+    if (parameterValues != null) {
+      parameterValue = (Boolean) parameterValues.get(parameterName);
+    }
+    if (parameterValue == null) {
+      parameterValue = true;
+    }
+    return parameterValue;
+  }
+}

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -60,6 +60,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
 
   @Autowired private EPTSCalculationService ePTSCalculationService;
 
+  @SuppressWarnings("unused")
   @Override
   public CalculationResultMap evaluate(
       Collection<Integer> cohort,

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
 import org.joda.time.DateTime;
 import org.joda.time.Months;
 import org.openmrs.Location;
@@ -90,10 +89,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             false,
             null,
             endDate,
-            Arrays.asList(
-                    hivMetadata.getAdultoSeguimentoEncounterType(),
-                    hivMetadata.getARVPediatriaSeguimentoEncounterType(),
-                    hivMetadata.getMasterCardEncounterType()),
+            null,
             cohort,
             context);
     CalculationResultMap startDrugsObservations =

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -153,7 +153,16 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
     }
     return null;
   }
-
+  /**
+   * Gets the earliest treatment start date by comparing the drugs start date obs from Seguimento
+   * (adults and children)” or “Ficha Resumo” and “Ficha Clinica-MasterCard”
+   *
+   * @param seguimentoOrFichaResumoDate The earliest drug start date obs from Seguimento (adults and
+   *     children)” or “Ficha Resumo”
+   * @param fichaClinicaMasterCardDate The earliest drug start date obs from Ficha
+   *     Clinica-MasterCard
+   * @return
+   */
   private Date getEarliestIptStartDate(
       Obs seguimentoOrFichaResumoDate, Obs fichaClinicaMasterCardDate) {
     if (seguimentoOrFichaResumoDate != null && fichaClinicaMasterCardDate != null) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
@@ -29,6 +29,7 @@ import org.openmrs.Program;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.eptsreports.metadata.HivMetadata;
 import org.openmrs.module.eptsreports.reporting.calculation.generic.AgeOnArtStartDateCalculation;
+import org.openmrs.module.eptsreports.reporting.calculation.generic.NewlyOrPreviouslyEnrolledOnARTCalculation;
 import org.openmrs.module.eptsreports.reporting.calculation.generic.StartedArtBeforeDateCalculation;
 import org.openmrs.module.eptsreports.reporting.calculation.generic.StartedArtOnPeriodCalculation;
 import org.openmrs.module.eptsreports.reporting.cohort.definition.CalculationCohortDefinition;
@@ -399,6 +400,18 @@ public class GenericCohortQueries {
             Context.getRegisteredComponents(StartedArtBeforeDateCalculation.class).get(0));
     cd.setName("Art start date");
     cd.addCalculationParameter("considerTransferredIn", considerTransferredIn);
+    cd.addParameter(new Parameter("location", "Location", Location.class));
+    cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
+    return cd;
+  }
+
+  public CohortDefinition getNewlyOrPreviouslyEnrolledOnART(boolean isNewlyEnrolledOnArtSearch) {
+    CalculationCohortDefinition cd =
+        new CalculationCohortDefinition(
+            Context.getRegisteredComponents(NewlyOrPreviouslyEnrolledOnARTCalculation.class)
+                .get(0));
+    cd.setName("Newly Or Previously Enrolled On ART");
+    cd.addCalculationParameter("isNewlyEnrolledOnArtSearch", isNewlyEnrolledOnArtSearch);
     cd.addParameter(new Parameter("location", "Location", Location.class));
     cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     return cd;

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
@@ -92,14 +92,13 @@ public class TbPrevCohortQueries {
   public CohortDefinition getNewOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV New on ART");
-    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
         "started-on-previous-period",
         EptsReportUtils.map(
-            genericCohortQueries.getStartedArtOnPeriod(false, true),
-            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
+            genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(true),
+            "onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.setCompositionString("started-on-previous-period");
     return definition;
   }
@@ -107,21 +106,14 @@ public class TbPrevCohortQueries {
   public CohortDefinition getPreviouslyOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV Previously on ART");
-    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
-        "started-on-previous-period",
-        EptsReportUtils.map(
-            genericCohortQueries.getStartedArtOnPeriod(false, true),
-            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
-    definition.addSearch(
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
-            genericCohortQueries.getStartedArtBeforeDate(false),
+            genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(false),
             "onOrBefore=${onOrBefore-6m},location=${location}"));
-    definition.setCompositionString(
-        "started-by-end-previous-reporting-period NOT started-on-previous-period");
+    definition.setCompositionString("started-by-end-previous-reporting-period");
     return definition;
   }
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
@@ -272,13 +272,12 @@ public class EptsCommonDimension {
     dim.addCohortDefinition(
         "new-on-art",
         EptsReportUtils.map(
-            tbPrevCohortQueries.getNewOnArt(),
-            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
+            tbPrevCohortQueries.getNewOnArt(), "onOrBefore=${onOrBefore},location=${location}"));
     dim.addCohortDefinition(
         "previously-on-art",
         EptsReportUtils.map(
             tbPrevCohortQueries.getPreviouslyOnArt(),
-            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
+            "onOrBefore=${onOrBefore},location=${location}"));
     return dim;
   }
 


### PR DESCRIPTION
- Added a new calculation `NewlyOrPreviouslyEnrolledOnARTCalculation` for calculating the date difference between the ART start date and IPT start date

- Added `#getNewlyOrPreviouslyEnrolledOnART()` method in `GenericCohortQueries` which used the newly added calculation

- Updated `#getNewOnArt()` and `#getPreviouslyOnArt()` methods of `TbPrevCohortQueries` to use the newly added calculation by calling `#getNewlyOrPreviouslyEnrolledOnART()` method.