### PR TITLE
MEPTS-386: Added #getFileOpeningObs metod to handle Ficha Resumo Encounter Type

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/metadata/CommonMetadata.java
@@ -231,4 +231,12 @@ public class CommonMetadata extends Metadata {
             .getGlobalProperty("eptsreports.isoniazidProphylaxisStartDateConceptUuid");
     return getConcept(uuid);
   }
+
+  //  concept_id=23891
+  public Concept getFileOpeningDateConcept() {
+    String uuid =
+        Context.getAdministrationService()
+            .getGlobalProperty("eptsreports.fileOpeningDateConceptUuid");
+    return getConcept(uuid);
+  }
 }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/PregnantDateCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/pvls/PregnantDateCalculation.java
@@ -65,19 +65,30 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
     Concept hivViraloadQualitative = hivMetadata.getHivViralLoadQualitative();
     Concept criteriaForArtStart = hivMetadata.getCriteriaForArtStart();
     Concept bPostive = hivMetadata.getBpostiveConcept();
-
+    Concept fileOpeningDate = hivMetadata.getFileOpeningDateConcept();
     // get female patients only
     Set<Integer> femaleCohort = EptsCalculationUtils.female(cohort, context);
 
     CalculationResultMap pregnantMap =
         ePTSCalculationService.getObs(
             pregnant,
-            Arrays.asList(fichaResumoEncounterType, adultFollowup, adultInitial),
+            Arrays.asList(adultFollowup, adultInitial),
             cohort,
             Arrays.asList(location),
             Arrays.asList(yes),
             TimeQualifier.ANY,
             null,
+            context);
+
+    CalculationResultMap fileOpeningObsMap =
+        ePTSCalculationService.getFileOpeningObs(
+            fichaResumoEncounterType,
+            fileOpeningDate,
+            pregnant,
+            yes,
+            cohort,
+            location,
+            oneYearBefore,
             context);
 
     CalculationResultMap markedPregnantByWeeks =
@@ -141,6 +152,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
           getRequiredDate(
               location,
               pregnantMap,
+              fileOpeningObsMap,
               markedPregnantByWeeks,
               markedPregnantDueDate,
               markedPregnantInProgram,
@@ -158,6 +170,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
   private Date getRequiredDate(
       Location location,
       CalculationResultMap pregnantMap,
+      CalculationResultMap fileOpeningObsMap,
       CalculationResultMap markedPregnantByWeeks,
       CalculationResultMap markedPregnantDueDate,
       CalculationResultMap markedPregnantInProgram,
@@ -180,6 +193,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
       Date lastVlDate = dateListForVl.get(dateListForVl.size() - 1);
 
       ListResult pregnantResult = (ListResult) pregnantMap.get(pId);
+      ListResult fileOpeningResult = (ListResult) fileOpeningObsMap.get(pId);
       ListResult pregnantByWeeksResullt = (ListResult) markedPregnantByWeeks.get(pId);
       ListResult pregnantDueDateResult = (ListResult) markedPregnantDueDate.get(pId);
       ListResult pregnantsInProgramResults = (ListResult) markedPregnantInProgram.get(pId);
@@ -187,6 +201,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
       ListResult onArtWhileBpos = (ListResult) artStartWhileBposMap.get(pId);
 
       List<Obs> pregnantObsList = EptsCalculationUtils.extractResultValues(pregnantResult);
+      List<Obs> fileOpeningObsList = EptsCalculationUtils.extractResultValues(fileOpeningResult);
       List<Obs> pregnantByWeeksObsList =
           EptsCalculationUtils.extractResultValues(pregnantByWeeksResullt);
       List<Obs> pregnantDueDateObsList =
@@ -200,6 +215,7 @@ public class PregnantDateCalculation extends AbstractPatientCalculation {
       List<Date> allPregnancyDates =
           Arrays.asList(
               isPregnantDate(lastVlDate, pregnantObsList),
+              isPregnantDate(lastVlDate, fileOpeningObsList),
               isPregnantByWeeks(lastVlDate, pregnantByWeeksObsList),
               isPregnantDueDate(lastVlDate, pregnantDueDateObsList),
               isPregnantInProgram(lastVlDate, patientProgams, location),

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -50,7 +50,14 @@
 		user to access Form Entry pages/functions</description> </privilege> /Required 
 		Privileges -->
 
-
+	<globalProperty>
+		<property>@MODULE_ID@.fileOpeningDateConceptUuid</property>
+		<defaultValue>68d65d0c-8fee-456b-8e95-caed990351e1</defaultValue>
+		<description>
+			UUID for the Master Card File Open Date concept
+		</description>
+	</globalProperty>
+	
 	<globalProperty>
 		<property>@MODULE_ID@.startDrugsConceptUuid</property>
 		<defaultValue>e1d9ef28-1d5f-11e0-b929-000c29ad1d07</defaultValue>


### PR DESCRIPTION
- Added `#getFileOpeningObs` method to process `fichaResumoEncounterType`

- Added  `CalculationResultMap fileOpeningObsMap` in both `BreastfeedingDateCalculation` and `PregnantDateCalculation` to handle `fichaResumoEncounterType` separately from `CalculationResultMap lactatingMap` and `CalculationResultMap pregnantMap`

- Updated `#getResultantDate` in `BreastfeedingDateCalculation` and `#getRequiredDate` in `PregnantDateCalculation` to accept `fileOpeningObsMap` as a parametter.

- Updated the above methods to get the list of file opening date obs as:
`      ListResult fileOpeningResults = (ListResult) fileOpeningObsMap.get(pId);
      List<Obs> fileOpeningObs = EptsCalculationUtils.extractResultValues(fileOpeningResults);`

**TODO**: 

- Replace ` this.isLactating(lastVlDate, fileOpeningObs),` in `BreastfeedingDateCalculation` with a dedicated method to handle `fichaResumoEncounterType`

- Replace `isPregnantDate(lastVlDate, fileOpeningObsList),`in `PregnantDateCalculation` with a dedicated method to handle `fichaResumoEncounterType`