### PR TITLE
MEPTS-424: RM: TB-Prev Investigate Differences in Disaggregations

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -12,6 +12,7 @@
 package org.openmrs.module.eptsreports.reporting.calculation.generic;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -83,6 +84,8 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
       endDate = (Date) context.getFromCache(ON_OR_BEFORE);
     }
 
+    // Start ART date is always checked against endDate, not endDate - 6m
+    parameterValues.put("onOrBefore", addMonths(endDate, 6));
     CalculationResultMap artStartDates =
         calculate(
             Context.getRegisteredComponents(InitialArtStartDateCalculation.class).get(0),
@@ -207,6 +210,19 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
       }
     }
     return false;
+  }
+  /**
+   * Adds a number of months to the passed-in date
+   *
+   * @param date the date to increment
+   * @param monthsToAdd the number of months to add
+   * @return date incremented by {monthsToAdd} months
+   */
+  public static Date addMonths(Date date, int monthsToAdd) {
+    Calendar cal = Calendar.getInstance();
+    cal.setTime(date);
+    cal.add(Calendar.MONTH, monthsToAdd);
+    return cal.getTime();
   }
 
   private boolean getBooleanParameter(Map<String, Object> parameterValues, String parameterName) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -54,6 +54,8 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
 
   private static final int MINIMUM_DURATION_IN_MONTHS = 6;
 
+  private static final String ON_OR_AFTER = "onOrAfter";
+
   private static final String ON_OR_BEFORE = "onOrBefore";
 
   @Autowired private HivMetadata hivMetadata;
@@ -70,7 +72,12 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
     boolean isNewlyEnrolledOnArtSearch =
         getBooleanParameter(parameterValues, "isNewlyEnrolledOnArtSearch");
     Location location = (Location) context.getFromCache("location");
+    Date startDate = (Date) parameterValues.get(ON_OR_AFTER);
     Date endDate = (Date) parameterValues.get(ON_OR_BEFORE);
+
+    if (startDate == null) {
+      startDate = (Date) context.getFromCache(ON_OR_AFTER);
+    }
 
     if (endDate == null) {
       endDate = (Date) context.getFromCache(ON_OR_BEFORE);
@@ -88,7 +95,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             null,
             location,
             false,
-            null,
+            startDate,
             endDate,
             null,
             cohort,
@@ -101,7 +108,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             Arrays.asList(location),
             Arrays.asList(hivMetadata.getStartDrugs()),
             TimeQualifier.FIRST,
-            null,
+            startDate,
             endDate,
             context);
     if (endDate != null) {
@@ -192,7 +199,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
     }
     if (artMinusIptStartDate
         == MINIMUM_DURATION_IN_MONTHS) { // Check if there are some days after the six months (eg. 6
-                                         // Months and 4 days)
+      // Months and 4 days)
       DateTime newEnd = iptStartDateTime.minusMonths(artMinusIptStartDate);
       int days = Days.daysBetween(artStartDateTime, newEnd).getDays();
       if (days > 0) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
@@ -409,6 +409,7 @@ public class GenericCohortQueries {
     cd.setName("Newly Or Previously Enrolled On ART");
     cd.addCalculationParameter("isNewlyEnrolledOnArtSearch", isNewlyEnrolledOnArtSearch);
     cd.addParameter(new Parameter("location", "Location", Location.class));
+    cd.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     return cd;
   }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
@@ -78,7 +78,7 @@ public class TbPrevCohortQueries {
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getStartedArtBeforeDate(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrBefore=${onOrBefore},location=${location}"));
     definition.addSearch(
         "completed-isoniazid",
         EptsReportUtils.map(
@@ -129,7 +129,7 @@ public class TbPrevCohortQueries {
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getStartedArtBeforeDate(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrBefore=${onOrBefore},location=${location}"));
     definition.addSearch(
         "started-isoniazid",
         EptsReportUtils.map(

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
@@ -92,13 +92,14 @@ public class TbPrevCohortQueries {
   public CohortDefinition getNewOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV New on ART");
+    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
         "started-on-previous-period",
         EptsReportUtils.map(
             genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(true),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.setCompositionString("started-on-previous-period");
     return definition;
   }
@@ -106,13 +107,14 @@ public class TbPrevCohortQueries {
   public CohortDefinition getPreviouslyOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV Previously on ART");
+    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.setCompositionString("started-by-end-previous-reporting-period");
     return definition;
   }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
@@ -276,12 +276,13 @@ public class EptsCommonDimension {
     dim.addCohortDefinition(
         "new-on-art",
         EptsReportUtils.map(
-            tbPrevCohortQueries.getNewOnArt(), "onOrBefore=${onOrBefore},location=${location}"));
+            tbPrevCohortQueries.getNewOnArt(),
+            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
     dim.addCohortDefinition(
         "previously-on-art",
         EptsReportUtils.map(
             tbPrevCohortQueries.getPreviouslyOnArt(),
-            "onOrBefore=${onOrBefore},location=${location}"));
+            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
     return dim;
   }
 


### PR DESCRIPTION
- Added `#isDateDiffGreaterThanSixMonths` method to handle cases where the difference might equal to six months.

If the difference in months between ART start date and IPT start date is equal to six months, we have to check if there is a remainder i.e -some days on top of the six months and then decide if the difference is really greater to 6 months.

- Added `starDate` parameter to `NewlyOrPreviouslyEnrolledOnARTCalculation` so it can be used to check the actual isoniazid start date

- To the reviewer: This PR has also implemented the change requested on MEPTS-434. The feature is implemented in [this commit](https://github.com/esaude/openmrs-module-eptsreports/pull/306/commits/3004605312549172568638379993627fae2d316f) and [this](https://github.com/esaude/openmrs-module-eptsreports/pull/306/commits/ab80cd0079e693594c37164e61d1d6626c551ddb). 